### PR TITLE
feat(eslint-config): drop prettier plugin

### DIFF
--- a/packages/create-web-scripts-library/src/messages.ts
+++ b/packages/create-web-scripts-library/src/messages.ts
@@ -12,8 +12,8 @@ Run ${chalk.cyan(`${program.name()} --help`)} to see all options.
 
 export const alreadyExists = (projectName: string) => `
 It looks like there's already a directory called "${chalk.cyan(
-  projectName,
-)}". Please try a different name or delete that folder.`;
+    projectName,
+  )}". Please try a different name or delete that folder.`;
 
 export const start = (projectName: string) => `
 Your project is now set up in "${chalk.cyan(projectName)}"! Try running
@@ -23,5 +23,5 @@ Your project is now set up in "${chalk.cyan(projectName)}"! Try running
   ${chalk.green('yarn build')}
 
 to see the web-scripts in action. When you're ready to publish your package, use ${chalk.green(
-  'yarn commit',
-)} and ${chalk.green('yarn release')} to use commitizen and semantic-release.`;
+    'yarn commit',
+  )} and ${chalk.green('yarn release')} to use commitizen and semantic-release.`;

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -3,8 +3,6 @@ module.exports = {
     '@spotify/eslint-config-base',
     '@spotify/eslint-config-react',
     '@spotify/eslint-config-typescript',
-    'prettier',
-    'prettier/@typescript-eslint',
   ],
   parser: '@typescript-eslint/parser',
   env: {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -22,7 +22,6 @@
     "@spotify/eslint-config-typescript": "^1.1.4",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
-    "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.12.4"
   },

--- a/packages/web-scripts/config/lint-staged.config.js
+++ b/packages/web-scripts/config/lint-staged.config.js
@@ -16,7 +16,7 @@ const lintRelatedChanges = `eslint ${
 // have to run the script in a way that the files aren't passed in.
 // we need to run tsc on the whole project.
 // https://github.com/okonet/lint-staged/issues/174#issuecomment-461423707
-const typecheckRelatedChanges = `bash -c \"tsc --noEmit\"`;
+const typecheckRelatedChanges = 'bash -c "tsc --noEmit"';
 
 const formatRelatedChanges = `prettier ${
   fix ? '--write' : '--check'

--- a/packages/web-scripts/src/integration.test.ts
+++ b/packages/web-scripts/src/integration.test.ts
@@ -26,16 +26,18 @@ const copyFile = promisify(copyFileFS);
 // log output after the command finishes
 const exec = async (cmd: string, options?: object) => {
   function _log(resp: { stdout?: string | Buffer; stderr?: string | Buffer }) {
-    if (resp.stdout)
+    if (resp.stdout) {
       resp.stdout
         .toString()
         .split('\n')
         .forEach(dbg);
-    if (resp.stderr)
+    }
+    if (resp.stderr) {
       resp.stderr
         .toString()
         .split('\n')
         .forEach(dbg);
+    }
   }
   try {
     const resp = await execPromise(cmd, options);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3164,13 +3164,6 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.0.0.tgz#f429a53bde9fc7660e6353910fd996d6284d3c25"
-  integrity sha512-vDrcCFE3+2ixNT5H83g28bO/uYAwibJxerXPj+E7op4qzBCsAV36QfvdAyVOoNxKAH2Os/e01T/2x++V0LPukA==
-  dependencies:
-    get-stdin "^6.0.0"
-
 eslint-plugin-jsx-a11y@^6.2.1:
   version "6.2.1"
   resolved "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz#4ebba9f339b600ff415ae4166e3e2e008831cf0c"
@@ -3813,11 +3806,6 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
-
-get-stdin@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
-  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
I was getting false positives in our base skeleton package when linting, so after investigating I
found that the prettier plugin can inadvertently shut down a lot of our rules. I'm turning it of